### PR TITLE
Remove hard coded path to codeql

### DIFF
--- a/lua/codeql/cliserver.lua
+++ b/lua/codeql/cliserver.lua
@@ -11,7 +11,7 @@ local function start()
 
   print("Starting CodeQL CLI Server")
 
-  local cmd = "/Users/pwntester/bin/codeql"
+  local cmd = "codeql"
   local cmd_args = {"execute", "cli-server", "--logdir", "/tmp/codeql_queryserver"}
 
   if not (vim.fn.executable(cmd) == 1) then


### PR DESCRIPTION
I wasn't able to run `SetDatabase` since the cliserver.lua script couldn't find /Users/pwntester/bin/codeql. I removed the absolute path.

The fix obviously relies on having codeql in your path, so if you want to go about this some other way that's completely understandable.