### PR TITLE
Fix sarif panel re-opening

### DIFF
--- a/lua/codeql/panel.lua
+++ b/lua/codeql/panel.lua
@@ -851,7 +851,7 @@ function M.open_panel(panel_name)
   local bufnr = vim.fn.bufnr(panel_name)
 
   -- check if audit pane is already opened
-  if bufnr and bufnr ~= -1 then
+  if get_panel_window(bufnr) and bufnr ~= -1 then
     return bufnr, get_panel_window(bufnr)
   end
 


### PR DESCRIPTION
Once the sarif panel is closed, `bufnr` still holds the buffer number. I guess the appropiate way to check if the window holding the sarif buffer has been closed is by using `get_panel_window`.
