### PR TITLE
DB Explorer: fix `explorer.draw()` race condition

### DIFF
--- a/lua/codeql/init.lua
+++ b/lua/codeql/init.lua
@@ -81,9 +81,7 @@ function M.set_database(dbpath)
       queryserver.register_database(metadata, function()
         explorer.draw()
       end)
-    end
-    -- show the side tree
-    
+    end    
   end
 end
 

--- a/lua/codeql/init.lua
+++ b/lua/codeql/init.lua
@@ -2,6 +2,7 @@ local util = require "codeql.util"
 local queryserver = require "codeql.queryserver"
 local config = require "codeql.config"
 local Path = require "plenary.path"
+local explorer = require'codeql.explorer'
 
 local M = {}
 
@@ -72,13 +73,17 @@ function M.set_database(dbpath)
 
     if not util.is_blank(config.database) then
       queryserver.unregister_database(function()
-        queryserver.register_database(metadata)
+        queryserver.register_database(metadata, function() 
+          explorer.draw()
+        end)
       end)
     else
-      queryserver.register_database(metadata)
+      queryserver.register_database(metadata, function()
+        explorer.draw()
+      end)
     end
     -- show the side tree
-    vim.cmd [[ArchiveTree]]
+    
   end
 end
 

--- a/lua/codeql/init.lua
+++ b/lua/codeql/init.lua
@@ -2,7 +2,6 @@ local util = require "codeql.util"
 local queryserver = require "codeql.queryserver"
 local config = require "codeql.config"
 local Path = require "plenary.path"
-local explorer = require'codeql.explorer'
 
 local M = {}
 
@@ -73,14 +72,10 @@ function M.set_database(dbpath)
 
     if not util.is_blank(config.database) then
       queryserver.unregister_database(function()
-        queryserver.register_database(metadata, function() 
-          explorer.draw()
-        end)
+        queryserver.register_database(metadata)
       end)
     else
-      queryserver.register_database(metadata, function()
-        explorer.draw()
-      end)
+      queryserver.register_database(metadata)
     end    
   end
 end

--- a/lua/codeql/queryserver.lua
+++ b/lua/codeql/queryserver.lua
@@ -279,7 +279,7 @@ function M.run_query(opts)
 
 end
 
-function M.register_database(database, cb)
+function M.register_database(database)
   if not M.client then
     M.client = M.start_server()
   end
@@ -301,10 +301,7 @@ function M.register_database(database, cb)
       util.err_message(string.format("Error registering database %s", vim.inspect(err)))
     else
       util.message(string.format("Successfully registered %s", result.registeredDatabases[1].dbDir))
-    end
-    -- call the callback
-    if cb then
-      cb()
+      require'codeql.explorer'.draw()
     end
   end)
 end

--- a/lua/codeql/queryserver.lua
+++ b/lua/codeql/queryserver.lua
@@ -279,7 +279,7 @@ function M.run_query(opts)
 
 end
 
-function M.register_database(database)
+function M.register_database(database, cb)
   if not M.client then
     M.client = M.start_server()
   end
@@ -301,6 +301,10 @@ function M.register_database(database)
       util.err_message(string.format("Error registering database %s", vim.inspect(err)))
     else
       util.message(string.format("Successfully registered %s", result.registeredDatabases[1].dbDir))
+    end
+    -- call the callback
+    if cb then
+      cb()
     end
   end)
 end


### PR DESCRIPTION
Reproduction:

* Set a database from the neo-tree panel
* Explorer loads fine
* Set another database from the neo-tree panel
* Explorer draws former database, because `explorer.draw()` happens before `config.database = database` in `queryserver.register_database(_)`.