### PR TITLE
Fix definition queries' qlpack

### DIFF
--- a/lua/codeql/init.lua
+++ b/lua/codeql/init.lua
@@ -192,12 +192,12 @@ function M.query(quick_eval, position)
 end
 
 local templated_queries = {
-  c = { qlpack = "codeql/cpp-queries" },
-  cpp = { qlpack = "codeql/cpp-queries" },
-  java = { qlpack = "codeql/java-queries" },
-  cs = { qlpack = "codeql/csharp-queries" },
-  javascript = { qlpack = "codeql/javascript-queries" },
-  python = { qlpack = "codeql/python-queries" },
+  c = { qlpack = "codeql/cpp-all" },
+  cpp = { qlpack = "codeql/cpp-all" },
+  java = { qlpack = "codeql/java-all" },
+  cs = { qlpack = "codeql/csharp-all" },
+  javascript = { qlpack = "codeql/javascript-all" },
+  python = { qlpack = "codeql/python-all" },
   ql = { qlpack = "codeql/ql", path = "ide-contextual/" },
   ruby = { qlpack = "codeql/ruby-queries", path = "ide-contextual/" },
   go = { qlpack = "codeql/go-all" },


### PR DESCRIPTION
Fix definition queries changed in https://github.com/github/codeql/commit/a3f4d1bf669f51dc4452113b060ba70df7a2c004. Now under `-all` instead of `-queries` in some cases.

// cc: @pwntester 